### PR TITLE
Add ip6tables to tailscale container for ipv6

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -35,7 +35,7 @@ LABEL org.opencontainers.image.source="https://github.com/jauderho/dockerfiles"
 LABEL org.opencontainers.image.title="jauderho/tailscale"
 LABEL org.opencontainers.image.description="Tailscale is Wireguard made easy"
 
-RUN apk add --no-cache ca-certificates iptables iproute2 \
+RUN apk add --no-cache ca-certificates iptables ip6tables iproute2 \
 	&& update-ca-certificates \
     && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
This should round out support for ipv6, as tailscale is unable to assign ipv6 addresses or routes without this binary in the path.