### PR TITLE
YT-DLP: Add a usage example with volume mounting

### DIFF
--- a/yt-dlp/README.md
+++ b/yt-dlp/README.md
@@ -1,5 +1,7 @@
 
-Usage: `docker run --rm -it jauderho/yt-dlp:latest `
+Usage: `docker run --rm -it jauderho/yt-dlp:latest`
+
+Download to the current directory: `docker run --rm -it -v "$(pwd):/downloads:rw" jauderho/yt-dlp:latest`
 
 [![Build Status](https://github.com/jauderho/dockerfiles/workflows/yt-dlp/badge.svg)](https://github.com/jauderho/dockerfiles/actions)
 [![Version](https://img.shields.io/docker/v/jauderho/yt-dlp/latest)](https://github.com/yt-dlp/yt-dlp)


### PR DESCRIPTION
`yt-dlp` as a standalone program will download to the current directory, and is presumably the most common use case.

This PR adds an example to the README, demonstrating how to download to the current directory.