### PR TITLE
changed yt-dlp installation to use pipx and inject yt-dlp-get-pot

### DIFF
--- a/yt-dlp/Dockerfile
+++ b/yt-dlp/Dockerfile
@@ -6,32 +6,33 @@ ARG DUMB_INIT_VERSION=1.2.5
 ARG BUILD_VERSION
 #ARG ARCHIVE_URL=https://github.com/yt-dlp/yt-dlp/archive/
 
-RUN set -x \
- && apk update \
- && apk upgrade -a \
- && apk add --no-cache \
-        ca-certificates \
-        curl \
-        dumb-init \
-        ffmpeg \
-        python3 \
-        py3-mutagen \
-    # Install youtube-dl
- && curl -Lo /usr/local/bin/yt-dlp https://github.com/yt-dlp/yt-dlp/releases/download/${BUILD_VERSION}/yt-dlp \
- #&& curl -Lo SHA2-256SUMS https://github.com/yt-dlp/yt-dlp/releases/download/${BUILD_VERSION}/SHA2-256SUMS \
- #&& cat SHA2-256SUMS | grep yt-dlp: | awk -F: '{print $2" "$1}' | sha256sum -c \
- && chmod a+rx /usr/local/bin/yt-dlp \
-    # Clean-up
- #&& rm SHA2-256SUMS \
- && apk del curl \
-    # Create directory to hold downloads.
- && mkdir /downloads \
- && chmod a+rw /downloads \
-    # Sets up cache.
- && mkdir /.cache \
- && chmod 777 /.cache
+# add pipx bin to path
+ENV PATH=/root/.local/bin:$PATH
+RUN echo 'export "PATH=$PATH:/root/.local/bin"' >> /etc/profile
 
-ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+RUN set -x \
+   && apk update \
+   && apk upgrade -a \
+   && apk add --no-cache \
+      # ca-certificates \
+      # curl \
+      dumb-init \
+      ffmpeg \
+      python3 \
+      py3-mutagen \
+      py3-pip \ 
+      pipx \
+   # Install youtube-dl
+   && pipx install yt-dlp \
+   && pipx inject yt-dlp yt-dlp-get-pot \
+   # Create directory to hold downloads
+   && mkdir /downloads \
+   && chmod a+rw /downloads \
+   # Sets up cache
+   && mkdir /.cache \
+   && chmod 777 /.cache
+
+# ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /downloads
 


### PR DESCRIPTION
changed yt-dlp installation to use pipx and also to inject yt-dlp-get-pot to handle new YouTube PO Token requirements
https://github.com/yt-dlp/yt-dlp/wiki/PO-Token-Guide
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changed `yt-dlp` installation to use `pipx` and injected `yt-dlp-get-pot` in `Dockerfile` to handle YouTube PO Token requirements.
> 
>   - **Installation Method**:
>     - Changed `yt-dlp` installation to use `pipx` in `Dockerfile`.
>     - Injected `yt-dlp-get-pot` into `yt-dlp` using `pipx inject` to handle YouTube PO Token requirements.
>   - **Environment Setup**:
>     - Added `pipx` binary path to `PATH` in `Dockerfile`.
>     - Updated `apk` packages to include `py3-pip` and `pipx`.
>   - **Misc**:
>     - Removed direct download and installation of `yt-dlp` binary via `curl`.
>     - Commented out `ca-certificates` and `curl` from `apk add` in `Dockerfile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jauderho%2Fdockerfiles&utm_source=github&utm_medium=referral)<sup> for eef2fd1946832eb45e5b9118a2e5b5a92420adef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->