### PR TITLE
Add production.cloudfront.docker.com to allowed endpoints

### DIFF
--- a/.github/workflows/adguardhome.yml
+++ b/.github/workflows/adguardhome.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/age.yml
+++ b/.github/workflows/age.yml
@@ -42,6 +42,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             index.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/ali.yml
+++ b/.github/workflows/ali.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -40,6 +40,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
           

--- a/.github/workflows/amass.yml
+++ b/.github/workflows/amass.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -54,6 +54,7 @@ jobs:
             pipelinesghubeus2.actions.githubusercontent.com:443
             ports.ubuntu.com:80
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             registry-1.docker.io:443
             security.ubuntu.com:80

--- a/.github/workflows/anteon.yml
+++ b/.github/workflows/anteon.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             rdfepirv2dm1prdstr02.blob.core.windows.net:443
             registry-1.docker.io:443

--- a/.github/workflows/aznamingtool.yml
+++ b/.github/workflows/aznamingtool.yml
@@ -48,6 +48,7 @@ jobs:
             index.docker.io:443
             mcr.microsoft.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             westus.data.mcr.microsoft.com:443
             westus2.data.mcr.microsoft.com:443

--- a/.github/workflows/bl3auto.yml
+++ b/.github/workflows/bl3auto.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -43,6 +43,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             pypi.org:443
             registry-1.docker.io:443

--- a/.github/workflows/catprinter.yml
+++ b/.github/workflows/catprinter.yml
@@ -50,6 +50,7 @@ jobs:
             pipelinesghubeus2.actions.githubusercontent.com:443
             ports.ubuntu.com:80
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             raw.githubusercontent.com:443
             registry-1.docker.io:443

--- a/.github/workflows/cf-warp.yml
+++ b/.github/workflows/cf-warp.yml
@@ -43,6 +43,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             index.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             registry.yarnpkg.com:443
           

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             rdfepirv2bl2prdstr03.blob.core.windows.net:443
             registry-1.docker.io:443

--- a/.github/workflows/coredns.yml
+++ b/.github/workflows/coredns.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/ddosify.yml
+++ b/.github/workflows/ddosify.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             rdfepirv2dm1prdstr02.blob.core.windows.net:443
             registry-1.docker.io:443

--- a/.github/workflows/dhcp-helper.yml
+++ b/.github/workflows/dhcp-helper.yml
@@ -40,6 +40,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443          
           
       - name: Source checkout

--- a/.github/workflows/dive.yml
+++ b/.github/workflows/dive.yml
@@ -44,6 +44,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/dkimpy.yml
+++ b/.github/workflows/dkimpy.yml
@@ -48,6 +48,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             ports.ubuntu.com:80
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             registry-1.docker.io:443
             security.ubuntu.com:80

--- a/.github/workflows/dnscontrol.yml
+++ b/.github/workflows/dnscontrol.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             rdfepirv2bl3prdstr01.blob.core.windows.net:443
             registry-1.docker.io:443

--- a/.github/workflows/dnscrypt-proxy.yml
+++ b/.github/workflows/dnscrypt-proxy.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/dnsx.yml
+++ b/.github/workflows/dnsx.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             rdfepirv2dm1prdstr02.blob.core.windows.net:443
             registry-1.docker.io:443

--- a/.github/workflows/docker-autocompose.yml
+++ b/.github/workflows/docker-autocompose.yml
@@ -47,6 +47,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             registry-1.docker.io:443
             www.piwheels.org:443

--- a/.github/workflows/docker-bench-security.yml
+++ b/.github/workflows/docker-bench-security.yml
@@ -41,6 +41,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
 
       - name: Source checkout

--- a/.github/workflows/driftctl.yml
+++ b/.github/workflows/driftctl.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/dry.yml
+++ b/.github/workflows/dry.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/dsq.yml
+++ b/.github/workflows/dsq.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/excalidraw.yml
+++ b/.github/workflows/excalidraw.yml
@@ -44,6 +44,7 @@ jobs:
             playwright.download.prss.microsoft.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
             rdfepirv2by3prdstr01.blob.core.windows.net:443

--- a/.github/workflows/fq.yml
+++ b/.github/workflows/fq.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/freenginx.yml
+++ b/.github/workflows/freenginx.yml
@@ -43,6 +43,7 @@ jobs:
             freenginx.org:80
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443
             www.openssl.org:443

--- a/.github/workflows/gobgp.yml
+++ b/.github/workflows/gobgp.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/gocannon.yml
+++ b/.github/workflows/gocannon.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -40,6 +40,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
           

--- a/.github/workflows/goplay2.yml
+++ b/.github/workflows/goplay2.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/goreplay.yml
+++ b/.github/workflows/goreplay.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/gotip.yml
+++ b/.github/workflows/gotip.yml
@@ -47,6 +47,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             go.googlesource.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/gron.yml
+++ b/.github/workflows/gron.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/hakrawler.yml
+++ b/.github/workflows/hakrawler.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/headscale.yml
+++ b/.github/workflows/headscale.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/httpie-go.yml
+++ b/.github/workflows/httpie-go.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/httprobe.yml
+++ b/.github/workflows/httprobe.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/httpx.yml
+++ b/.github/workflows/httpx.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/imapsync.yml
+++ b/.github/workflows/imapsync.yml
@@ -47,6 +47,7 @@ jobs:
             imapsync.lamiral.info:443
             ports.ubuntu.com:80
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             raw.githubusercontent.com:443
             registry-1.docker.io:443
             security.ubuntu.com:80

--- a/.github/workflows/lego.yml
+++ b/.github/workflows/lego.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/log4j-scan.yml
+++ b/.github/workflows/log4j-scan.yml
@@ -43,6 +43,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             pypi.org:443
             registry-1.docker.io:443

--- a/.github/workflows/logmepwn.yml
+++ b/.github/workflows/logmepwn.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/lpar2rrd.yml
+++ b/.github/workflows/lpar2rrd.yml
@@ -43,6 +43,7 @@ jobs:
             index.docker.io:443
             lpar2rrd.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             www.cpan.org:80
           

--- a/.github/workflows/miller.yml
+++ b/.github/workflows/miller.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/nebula.yml
+++ b/.github/workflows/nebula.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/netmaker.yml
+++ b/.github/workflows/netmaker.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/nginx-distroless.yml
+++ b/.github/workflows/nginx-distroless.yml
@@ -44,6 +44,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/nginx-quic.yml
+++ b/.github/workflows/nginx-quic.yml
@@ -52,6 +52,7 @@ jobs:
             hg.nginx.org:443
             ports.ubuntu.com:80
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             security.ubuntu.com:80
@@ -134,6 +135,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             hg.nginx.org:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
           

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -43,6 +43,7 @@ jobs:
             nginx.org:80
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443
             www.openssl.org:443

--- a/.github/workflows/ntfy.yml
+++ b/.github/workflows/ntfy.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             rdfepirv2bl3prdstr01.blob.core.windows.net:443

--- a/.github/workflows/octosql.yml
+++ b/.github/workflows/octosql.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/onetun.yml
+++ b/.github/workflows/onetun.yml
@@ -44,6 +44,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             index.crates.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             static.crates.io:443
 

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -43,6 +43,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/pia-wg.yml
+++ b/.github/workflows/pia-wg.yml
@@ -48,6 +48,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             ports.ubuntu.com:80
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             registry-1.docker.io:443
             security.ubuntu.com:80

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             registry.npmjs.org:443
           

--- a/.github/workflows/pwru.yml
+++ b/.github/workflows/pwru.yml
@@ -49,6 +49,7 @@ jobs:
             index.docker.io:443
             ports.ubuntu.com:80
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             security.ubuntu.com:80

--- a/.github/workflows/rclone.yml
+++ b/.github/workflows/rclone.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/rdap.yml
+++ b/.github/workflows/rdap.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -47,6 +47,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             registry-1.docker.io:443
             www.piwheels.org:443

--- a/.github/workflows/rustybgp.yml
+++ b/.github/workflows/rustybgp.yml
@@ -41,6 +41,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             index.crates.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             sh.rustup.rs:443
             static.crates.io:443

--- a/.github/workflows/sftpd.yml
+++ b/.github/workflows/sftpd.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
           

--- a/.github/workflows/snowball.yml
+++ b/.github/workflows/snowball.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             security.ubuntu.com:80
             snowball-client.s3.us-west-2.amazonaws.com:443

--- a/.github/workflows/spicedb.yml
+++ b/.github/workflows/spicedb.yml
@@ -41,6 +41,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             index.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/ssh-audit.yml
+++ b/.github/workflows/ssh-audit.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
           

--- a/.github/workflows/sslyze.yml
+++ b/.github/workflows/sslyze.yml
@@ -48,6 +48,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             registry-1.docker.io:443
             security.ubuntu.com:80

--- a/.github/workflows/stor2rrd.yml
+++ b/.github/workflows/stor2rrd.yml
@@ -42,6 +42,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             index.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             stor2rrd.com:443
             www.cpan.org:80

--- a/.github/workflows/subfinder.yml
+++ b/.github/workflows/subfinder.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/tailscale.yml
+++ b/.github/workflows/tailscale.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/testssl.sh.yml
+++ b/.github/workflows/testssl.sh.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
           

--- a/.github/workflows/textql.yml
+++ b/.github/workflows/textql.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/tftpd.yml
+++ b/.github/workflows/tftpd.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
           

--- a/.github/workflows/toxiproxy.yml
+++ b/.github/workflows/toxiproxy.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             rdfepirv2by3prdstr02.blob.core.windows.net:443
             rdfepirv2bl2prdstr03.blob.core.windows.net:443

--- a/.github/workflows/unbound.yml
+++ b/.github/workflows/unbound.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
           
       - name: Source checkout

--- a/.github/workflows/update-hashes.yml
+++ b/.github/workflows/update-hashes.yml
@@ -48,6 +48,7 @@ jobs:
             objects.githubusercontent.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             raw.githubusercontent.com:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443

--- a/.github/workflows/vegeta.yml
+++ b/.github/workflows/vegeta.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/visidata.yml
+++ b/.github/workflows/visidata.yml
@@ -47,6 +47,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             pypi.org:443
             registry-1.docker.io:443
             www.piwheels.org:443

--- a/.github/workflows/watchtower.yml
+++ b/.github/workflows/watchtower.yml
@@ -41,6 +41,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/whois.yml
+++ b/.github/workflows/whois.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/wuzz.yml
+++ b/.github/workflows/wuzz.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             sum.golang.org:443

--- a/.github/workflows/yggdrasil-go.yml
+++ b/.github/workflows/yggdrasil-go.yml
@@ -42,6 +42,7 @@ jobs:
             github.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             storage.googleapis.com:443

--- a/.github/workflows/youtube-dl.yml
+++ b/.github/workflows/youtube-dl.yml
@@ -43,6 +43,7 @@ jobs:
             keyserver.ubuntu.com:11371
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry-1.docker.io:443
             release-assets.githubusercontent.com:443
             yt-dl.org:443

--- a/.github/workflows/yt-dlp-nightly-builds.yml
+++ b/.github/workflows/yt-dlp-nightly-builds.yml
@@ -43,6 +43,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
           

--- a/.github/workflows/yt-dlp.yml
+++ b/.github/workflows/yt-dlp.yml
@@ -43,6 +43,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
           

--- a/.github/workflows/zola.yml
+++ b/.github/workflows/zola.yml
@@ -44,6 +44,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             index.crates.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             rdfepirv2by3prdstr02.blob.core.windows.net:443
             registry-1.docker.io:443
             static.crates.io:443


### PR DESCRIPTION
Added `production.cloudfront.docker.com:443` to the `allowed-endpoints` list in 89 GitHub Action workflows. This ensures compatibility with Docker's multi-provider CDN distribution (Cloudflare and CloudFront) for workflows using Step Security's Harden Runner. All modified workflows were validated with `actionlint`.

Fixes #7258

---
*PR created automatically by Jules for task [7804771902056376939](https://jules.google.com/task/7804771902056376939) started by @jauderho*