### PR TITLE
Install `py3-pycryptodomex` to enable native AES decryption

### DIFF
--- a/yt-dlp/Dockerfile
+++ b/yt-dlp/Dockerfile
@@ -19,6 +19,7 @@ RUN set -x \
         py3-pip \
         zstd \
         nghttp2 \
+        py3-pycryptodomex \
  && apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/edge/community deno simdutf \
  && apk add --no-cache --virtual .build-deps \
         curl \

--- a/yt-dlp/Dockerfile.nightly
+++ b/yt-dlp/Dockerfile.nightly
@@ -16,6 +16,7 @@ RUN set -x \
         ffmpeg \
         python3 \
         py3-mutagen \
+        py3-pycryptodomex \
  && apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/edge/community deno simdutf \
  && apk add --no-cache --virtual .build-deps \
         curl \


### PR DESCRIPTION
## What

Adds `py3-pycryptodomex` to the `yt-dlp` imagem so it can use the C-based AES implementation instead of falling back to its pure-Python decryptor.

## Why

Without `Cryptodome` (or `Crypto`) importable, yt-dlp prints:

> WARNING: The stream has AES-128 encryption and pycryptodomex is not available; decryption will be performed natively, but will be extremely slow

"Extremely slow" is not an exaggeration — pure-Python AES-CBC is roughly 100–1000× slower than the C implementation. For any HLS stream encrypted with AES-128 (common with ad-supported services that use server-side ad insertion), this turns a network-bound download into a CPU-bound one that can take many hours instead of minutes.

Concrete repro: a ~3.9 GiB HLS stream from 10play (523 fragments). With native decryption, the download stalls at fragment 1 for several minutes per fragment. After `apk add py3-pycryptodomex`, it completes at network speed.
