### PR TITLE
yt-dlp: derive curl_cffi constraint from yt-dlp at build time

### DIFF
--- a/yt-dlp/Dockerfile
+++ b/yt-dlp/Dockerfile
@@ -31,8 +31,10 @@ RUN set -x \
         nghttp2-dev \
         libffi-dev \
  && cd /usr/local/bin \
- && curl -Lo yt-dlp ${RELEASE_URL}${BUILD_VERSION}/yt-dlp \
- && curl -Lo SHA2-256SUMS ${RELEASE_URL}${BUILD_VERSION}/SHA2-256SUMS \
+ && curl -Lo yt-dlp --proto "=https" --proto-redir "=https" \
+        "${RELEASE_URL}${BUILD_VERSION}/yt-dlp" \
+ && curl -Lo SHA2-256SUMS --proto "=https" --proto-redir "=https" \
+        "${RELEASE_URL}${BUILD_VERSION}/SHA2-256SUMS" \
  && cat SHA2-256SUMS | grep "yt-dlp$" | sha256sum -csw - \
  && chmod a+rx /usr/local/bin/yt-dlp \
  # Conditionally install curl_cffi only on supported arches, constrained to the

--- a/yt-dlp/Dockerfile
+++ b/yt-dlp/Dockerfile
@@ -41,9 +41,17 @@ RUN set -x \
  # https://github.com/jauderho/dockerfiles/issues/7774
  && case "$(uname -m)" in \
        x86_64|aarch64) \
-            curl -Lo yt-dlp.tar.gz ${RELEASE_URL}${BUILD_VERSION}/yt-dlp.tar.gz \
+            curl -Lo yt-dlp.tar.gz --proto "=https" --proto-redir "=https" \
+                 "${RELEASE_URL}${BUILD_VERSION}/yt-dlp.tar.gz" \
          && cat SHA2-256SUMS | grep "yt-dlp.tar.gz$" | sha256sum -csw - \
-         && CURL_CFFI_REQ="$(python3 -c 'import tarfile,tomllib; t=tarfile.open("yt-dlp.tar.gz"); n=[i for i in t.getnames() if i.count("/")==1 and i.endswith("/pyproject.toml")][0]; d=tomllib.load(t.extractfile(n)); print(next(r.split(";")[0].strip() for r in d["project"]["optional-dependencies"]["curl-cffi"] if r.replace("_","-").lower().startswith("curl-cffi")))')" \
+         && CURL_CFFI_REQ="$(python3 -c 'import tarfile, tomllib; \
+                t = tarfile.open("yt-dlp.tar.gz"); \
+                n = [i for i in t.getnames() if i.count("/") == 1 \
+                     and i.endswith("/pyproject.toml")][0]; \
+                d = tomllib.load(t.extractfile(n)); \
+                e = d["project"]["optional-dependencies"]["curl-cffi"]; \
+                r = [x for x in e if x.lower().startswith("curl")][0]; \
+                print(r.split(";")[0].strip())')" \
          && echo "yt-dlp ${BUILD_VERSION} requires ${CURL_CFFI_REQ}" \
          && python3 -m pip install --no-cache-dir "${CURL_CFFI_REQ}" --break-system-packages \
          && rm yt-dlp.tar.gz ;; \

--- a/yt-dlp/Dockerfile
+++ b/yt-dlp/Dockerfile
@@ -35,9 +35,18 @@ RUN set -x \
  && curl -Lo SHA2-256SUMS ${RELEASE_URL}${BUILD_VERSION}/SHA2-256SUMS \
  && cat SHA2-256SUMS | grep "yt-dlp$" | sha256sum -csw - \
  && chmod a+rx /usr/local/bin/yt-dlp \
- # Conditionally install curl_cffi only on supported arches
+ # Conditionally install curl_cffi only on supported arches, constrained to the
+ # range yt-dlp declares for its curl-cffi extra. Installing outside that range
+ # makes yt-dlp silently drop the impersonate handler.
+ # https://github.com/jauderho/dockerfiles/issues/7774
  && case "$(uname -m)" in \
-       x86_64|aarch64) python3 -m pip install --no-cache-dir curl_cffi --break-system-packages ;; \
+       x86_64|aarch64) \
+            curl -Lo yt-dlp.tar.gz ${RELEASE_URL}${BUILD_VERSION}/yt-dlp.tar.gz \
+         && cat SHA2-256SUMS | grep "yt-dlp.tar.gz$" | sha256sum -csw - \
+         && CURL_CFFI_REQ="$(python3 -c 'import tarfile,tomllib; t=tarfile.open("yt-dlp.tar.gz"); n=[i for i in t.getnames() if i.count("/")==1 and i.endswith("/pyproject.toml")][0]; d=tomllib.load(t.extractfile(n)); print(next(r.split(";")[0].strip() for r in d["project"]["optional-dependencies"]["curl-cffi"] if r.replace("_","-").lower().startswith("curl-cffi")))')" \
+         && echo "yt-dlp ${BUILD_VERSION} requires ${CURL_CFFI_REQ}" \
+         && python3 -m pip install --no-cache-dir "${CURL_CFFI_REQ}" --break-system-packages \
+         && rm yt-dlp.tar.gz ;; \
        *) echo "Skipping curl_cffi: unsupported arch $(uname -m)" ;; \
     esac \
  # Clean-up
@@ -57,7 +66,16 @@ WORKDIR /downloads
 VOLUME ["/downloads"]
 
 # Basic check.
-RUN dumb-init yt-dlp --version
+RUN dumb-init yt-dlp --version \
+ # Fail loudly if the installed curl_cffi is not usable for impersonation.
+ && case "$(uname -m)" in \
+       x86_64|aarch64) \
+            dumb-init yt-dlp --list-impersonate-targets > /tmp/impersonate-targets \
+         && cat /tmp/impersonate-targets \
+         && grep curl_cffi /tmp/impersonate-targets | grep -qv "(unavailable)" \
+         && rm /tmp/impersonate-targets ;; \
+       *) echo "Skipping impersonate check: unsupported arch $(uname -m)" ;; \
+    esac
 
 ENTRYPOINT ["dumb-init", "yt-dlp"]
 CMD ["--help"]

--- a/yt-dlp/Dockerfile.nightly
+++ b/yt-dlp/Dockerfile.nightly
@@ -31,8 +31,10 @@ RUN set -x \
         nghttp2-dev \
         libffi-dev \
  && cd /usr/local/bin \
- && curl -Lo yt-dlp ${RELEASE_URL}${BUILD_VERSION}/yt-dlp \
- && curl -Lo SHA2-256SUMS ${RELEASE_URL}${BUILD_VERSION}/SHA2-256SUMS \
+ && curl -Lo yt-dlp --proto "=https" --proto-redir "=https" \
+        "${RELEASE_URL}${BUILD_VERSION}/yt-dlp" \
+ && curl -Lo SHA2-256SUMS --proto "=https" --proto-redir "=https" \
+        "${RELEASE_URL}${BUILD_VERSION}/SHA2-256SUMS" \
  && cat SHA2-256SUMS | grep "yt-dlp$" | sha256sum -csw - \
  && chmod a+rx /usr/local/bin/yt-dlp \
  # Conditionally install curl_cffi only on supported arches, constrained to the

--- a/yt-dlp/Dockerfile.nightly
+++ b/yt-dlp/Dockerfile.nightly
@@ -41,9 +41,17 @@ RUN set -x \
  # https://github.com/jauderho/dockerfiles/issues/7774
  && case "$(uname -m)" in \
        x86_64|aarch64) \
-            curl -Lo yt-dlp.tar.gz ${RELEASE_URL}${BUILD_VERSION}/yt-dlp.tar.gz \
+            curl -Lo yt-dlp.tar.gz --proto "=https" --proto-redir "=https" \
+                 "${RELEASE_URL}${BUILD_VERSION}/yt-dlp.tar.gz" \
          && cat SHA2-256SUMS | grep "yt-dlp.tar.gz$" | sha256sum -csw - \
-         && CURL_CFFI_REQ="$(python3 -c 'import tarfile,tomllib; t=tarfile.open("yt-dlp.tar.gz"); n=[i for i in t.getnames() if i.count("/")==1 and i.endswith("/pyproject.toml")][0]; d=tomllib.load(t.extractfile(n)); print(next(r.split(";")[0].strip() for r in d["project"]["optional-dependencies"]["curl-cffi"] if r.replace("_","-").lower().startswith("curl-cffi")))')" \
+         && CURL_CFFI_REQ="$(python3 -c 'import tarfile, tomllib; \
+                t = tarfile.open("yt-dlp.tar.gz"); \
+                n = [i for i in t.getnames() if i.count("/") == 1 \
+                     and i.endswith("/pyproject.toml")][0]; \
+                d = tomllib.load(t.extractfile(n)); \
+                e = d["project"]["optional-dependencies"]["curl-cffi"]; \
+                r = [x for x in e if x.lower().startswith("curl")][0]; \
+                print(r.split(";")[0].strip())')" \
          && echo "yt-dlp ${BUILD_VERSION} requires ${CURL_CFFI_REQ}" \
          && python3 -m pip install --no-cache-dir "${CURL_CFFI_REQ}" --break-system-packages \
          && rm yt-dlp.tar.gz ;; \

--- a/yt-dlp/Dockerfile.nightly
+++ b/yt-dlp/Dockerfile.nightly
@@ -35,9 +35,18 @@ RUN set -x \
  && curl -Lo SHA2-256SUMS ${RELEASE_URL}${BUILD_VERSION}/SHA2-256SUMS \
  && cat SHA2-256SUMS | grep "yt-dlp$" | sha256sum -csw - \
  && chmod a+rx /usr/local/bin/yt-dlp \
- # Conditionally install curl_cffi only on supported arches
+ # Conditionally install curl_cffi only on supported arches, constrained to the
+ # range yt-dlp declares for its curl-cffi extra. Installing outside that range
+ # makes yt-dlp silently drop the impersonate handler.
+ # https://github.com/jauderho/dockerfiles/issues/7774
  && case "$(uname -m)" in \
-       x86_64|aarch64) python3 -m pip install --no-cache-dir curl_cffi --break-system-packages ;; \
+       x86_64|aarch64) \
+            curl -Lo yt-dlp.tar.gz ${RELEASE_URL}${BUILD_VERSION}/yt-dlp.tar.gz \
+         && cat SHA2-256SUMS | grep "yt-dlp.tar.gz$" | sha256sum -csw - \
+         && CURL_CFFI_REQ="$(python3 -c 'import tarfile,tomllib; t=tarfile.open("yt-dlp.tar.gz"); n=[i for i in t.getnames() if i.count("/")==1 and i.endswith("/pyproject.toml")][0]; d=tomllib.load(t.extractfile(n)); print(next(r.split(";")[0].strip() for r in d["project"]["optional-dependencies"]["curl-cffi"] if r.replace("_","-").lower().startswith("curl-cffi")))')" \
+         && echo "yt-dlp ${BUILD_VERSION} requires ${CURL_CFFI_REQ}" \
+         && python3 -m pip install --no-cache-dir "${CURL_CFFI_REQ}" --break-system-packages \
+         && rm yt-dlp.tar.gz ;; \
        *) echo "Skipping curl_cffi: unsupported arch $(uname -m)" ;; \
     esac \
  # Clean-up
@@ -57,7 +66,16 @@ WORKDIR /downloads
 VOLUME ["/downloads"]
 
 # Basic check.
-RUN dumb-init yt-dlp --version
+RUN dumb-init yt-dlp --version \
+ # Fail loudly if the installed curl_cffi is not usable for impersonation.
+ && case "$(uname -m)" in \
+       x86_64|aarch64) \
+            dumb-init yt-dlp --list-impersonate-targets > /tmp/impersonate-targets \
+         && cat /tmp/impersonate-targets \
+         && grep curl_cffi /tmp/impersonate-targets | grep -qv "(unavailable)" \
+         && rm /tmp/impersonate-targets ;; \
+       *) echo "Skipping impersonate check: unsupported arch $(uname -m)" ;; \
+    esac
 
 ENTRYPOINT ["dumb-init", "yt-dlp"]
 CMD ["--help"]


### PR DESCRIPTION
Implements option 2 from #7774, per the preference in https://github.com/jauderho/dockerfiles/issues/7774#issuecomment-5261655903. Reported and diagnosed by @sergioccrr.

## Problem

yt-dlp gates its curl_cffi request handler on a version range checked at import time. The Dockerfiles installed whatever the latest curl_cffi release happened to be, which drifted above that range — so the handler never loaded and every impersonate target reported `(unavailable)`. Nothing in the build signalled it, which is why it went unnoticed.

## Changes

Applied identically to `yt-dlp/Dockerfile` and `yt-dlp/Dockerfile.nightly`:

1. **Derive the constraint at build time.** Download the release's own `yt-dlp.tar.gz`, verify it against the `SHA2-256SUMS` already being fetched, read `[project.optional-dependencies].curl-cffi` from its `pyproject.toml` with stdlib `tomllib`, strip the PEP 508 environment marker, and hand the specifier to pip.

2. **Assert impersonation works before the image ships.** The existing basic-check `RUN` now also runs `--list-impersonate-targets` and fails the build if no `curl_cffi` target is available.

## Notes for review

**Why the tarball and not the repo's `pyproject.toml`.** The nightly builds repo is release-only — `raw.githubusercontent.com/yt-dlp/yt-dlp-nightly-builds/<tag>/pyproject.toml` 404s. The `yt-dlp.tar.gz` asset is published for both stable and nightly, so one code path covers both, it's checksum-verified, and it's version-matched to the exact binary being installed rather than to `master`. Cost is a 6 MB download in the build deps stage, removed before the layer ends.

**Why "at least one target available" and not "all targets available".** Individual targets carry their own minimum (`curl_cffi>=0.11` for Tor, `>=0.10` for Firefox). Asserting all of them would fire spuriously if a target ever requires a newer curl_cffi than the declared range permits. Asserting at least one precisely captures "the handler loaded".

**Failure mode is loud.** If the specifier can't be derived, the `python3 -c` exits non-zero and the build fails rather than falling back to an unconstrained install.

## Verification

Built locally against both Dockerfiles:

| Test | Result |
|---|---|
| stable `2026.07.04`, arm64 | derived `<0.16` → installed **0.15.0**, all targets available |
| stable `2026.07.04`, amd64 | same, check passes |
| nightly `2026.08.16.020253` | derived `<0.17` → installed **0.16.0**, all targets available |
| runtime `--impersonate chrome -v` | `Request Handlers: urllib, curl_cffi`; `curl_cffi-0.16.0` with no `(unsupported)` suffix |
| negative control: forced `curl_cffi==0.16.0` on stable | **build fails** at the check step, as intended |

The stable/nightly split (0.15.0 vs 0.16.0) is the drift a hardcoded pin would have reintroduced.

Parser also checked against older specifier formatting: `2025.09.26` (`<0.14;implementation_name=='cpython'`, no space before `;`) and `2024.08.06` (`curl-cffi==0.5.10`) both parse correctly.

## Left alone deliberately

`zstd-dev`, `nghttp2-dev` and `build-base` are now unnecessary, since pip resolves to a prebuilt `musllinux` wheel. Removing them is out of scope here and would silently break the build if a future range ever forces a source build.
