### PR TITLE
Enforce HTTPS on all curl downloads

### DIFF
--- a/adguardhome/Dockerfile
+++ b/adguardhome/Dockerfile
@@ -18,7 +18,8 @@ RUN test -n "${BUILD_VERSION}" \
 	# The web UI is embedded into the binary at compile time via //go:embed build.
 	# A fresh clone ships an empty build/ dir, so fetch the prebuilt frontend and
 	# extract it into build/ before "go build" or the UI renders a blank screen.
-	&& curl -fsSL https://github.com/AdguardTeam/AdGuardHome/releases/download/${BUILD_VERSION}/AdGuardHome_frontend.tar.gz \
+	&& curl -fsSL --proto "=https" --proto-redir "=https" \
+		https://github.com/AdguardTeam/AdGuardHome/releases/download/${BUILD_VERSION}/AdGuardHome_frontend.tar.gz \
 		| tar xzf - -C /go/src/github.com/adguardteam/adguardhome \
 	&& test -f /go/src/github.com/adguardteam/adguardhome/build/static/index.html \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/adguardhome/Dockerfile
+++ b/adguardhome/Dockerfile
@@ -19,7 +19,7 @@ RUN test -n "${BUILD_VERSION}" \
 	# A fresh clone ships an empty build/ dir, so fetch the prebuilt frontend and
 	# extract it into build/ before "go build" or the UI renders a blank screen.
 	&& curl -fsSL --proto "=https" --proto-redir "=https" \
-		https://github.com/AdguardTeam/AdGuardHome/releases/download/${BUILD_VERSION}/AdGuardHome_frontend.tar.gz \
+		"https://github.com/AdguardTeam/AdGuardHome/releases/download/${BUILD_VERSION}/AdGuardHome_frontend.tar.gz" \
 		| tar xzf - -C /go/src/github.com/adguardteam/adguardhome \
 	&& test -f /go/src/github.com/adguardteam/adguardhome/build/static/index.html \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/ali/Dockerfile
+++ b/ali/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/ali.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/ali.tar.gz \
 	&& tar xzf /tmp/ali.tar.gz --strip 1 -C /go/src/github.com/nakabonne/ali \
 	&& go get -u golang.org/x/net \
 	&& go mod tidy -compat=1.20 \

--- a/amass/Dockerfile
+++ b/amass/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/amass.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/amass.tar.gz \
 	&& tar xzf /tmp/amass.tar.gz --strip 1 -C /go/src/github.com/owasp/amass \
 	&& go get -u github.com/jackc/pgx/v5 google.golang.org/protobuf github.com/golang/glog \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/anteon/Dockerfile
+++ b/anteon/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk update \
 	&& apk upgrade -a \
 	&& apk add --no-cache curl gcc musl-dev \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/anteon.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/anteon.tar.gz \
 	&& tar xzf /tmp/anteon.tar.gz --strip 1 -C /go/src/github.com/getanteon/anteon \
 	&& cd ddosify_engine \
 	&& go get -u golang.org/x/net \

--- a/bl3auto/Dockerfile
+++ b/bl3auto/Dockerfile
@@ -13,7 +13,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc build-base \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/bl3auto.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/bl3auto.tar.gz \
 	&& tar xzf /tmp/bl3auto.tar.gz --strip 1 -C /go/src/github.com/jauderho/bl3auto \
 	&& go get -u golang.org/x/net \
 	&& go build -v -trimpath -ldflags="-s -w" ./cmd/bl3auto.go

--- a/catprinter/Dockerfile
+++ b/catprinter/Dockerfile
@@ -23,7 +23,8 @@ RUN \
 	DEBIAN_FRONTEND=${DEBIAN_FRONTEND} apt-get install -y --no-install-recommends ${build_pkgs} ${runtime_pkgs} && \
 	python3 -m pip install --no-cache-dir --upgrade pip --ignore-installed --break-system-packages && \
 	pip3 install --no-cache-dir -r requirements.txt --break-system-packages && \
-	curl -o /usr/local/bin/print.py https://raw.githubusercontent.com/jauderho/catprinter/main/print.py && \
+	curl -o /usr/local/bin/print.py --proto "=https" --proto-redir "=https" \
+		https://raw.githubusercontent.com/jauderho/catprinter/main/print.py && \
 	apt-get purge -y ${build_pkgs} && \
 	rm -rf /usr/bin/pebble && \
 	apt-get autoremove -y --purge && \

--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -13,7 +13,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc build-base bind-tools libcap \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/cloudflared.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/cloudflared.tar.gz \
 	&& tar xzf /tmp/cloudflared.tar.gz --strip 1 -C /go/src/github.com/cloudflare/cloudflared \
 	#&& go get -u github.com/cloudflare/circl github.com/go-jose/go-jose/v3 google.golang.org/protobuf \
 	#&& go get -u github.com/coredns/coredns \

--- a/coredns/Dockerfile
+++ b/coredns/Dockerfile
@@ -14,7 +14,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl make git gcc build-base \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/coredns.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/coredns.tar.gz \
 	&& tar xzf /tmp/coredns.tar.gz --strip 1 -C /go/src/github.com/coredns/coredns \
 	&& go get -u golang.org/x/crypto golang.org/x/net google.golang.org/grpc google.golang.org/protobuf \
 	#&& go get -u github.com/quic-go/quic-go \

--- a/ddosify/Dockerfile
+++ b/ddosify/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk update \
 	&& apk upgrade -a \
 	&& apk add --no-cache curl gcc musl-dev \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/ddosify.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/ddosify.tar.gz \
 	&& tar xzf /tmp/ddosify.tar.gz --strip 1 -C /go/src/github.com/ddosify/ddosify \
 	&& go get -u golang.org/x/net \
 	&& go mod tidy \

--- a/dnscontrol/Dockerfile
+++ b/dnscontrol/Dockerfile
@@ -14,7 +14,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc build-base git \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/dnscontrol.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/dnscontrol.tar.gz \
 	&& tar xzf /tmp/dnscontrol.tar.gz --strip 1 -C /go/src/github.com/StackExchange/dnscontrol \
 	&& go build -v -trimpath -ldflags="-s -w -X main.Version=${BUILD_VERSION}" \
 	&& cp dnscontrol /go/bin/dnscontrol \

--- a/dnscrypt-proxy/Dockerfile
+++ b/dnscrypt-proxy/Dockerfile
@@ -16,7 +16,8 @@ RUN test -n "${BUILD_VERSION}" \
 	#&& git clone --depth 1 ${GIT_URL} --branch ${BUILD_VERSION} /go/src/github.com/DNSCrypt/dnscrypt-proxy \
 	#&& git clone --depth 1 ${GIT_URL} /go/src/github.com/DNSCrypt/dnscrypt-proxy \
 	#&& cd /go/src/github.com/DNSCrypt/dnscrypt-proxy \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/dnscrypt-proxy.tar.gz \
+	&& curl -L --proto "=https" --proto-redir "=https" \
+		"${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/dnscrypt-proxy.tar.gz \
 	&& tar xzf /tmp/dnscrypt-proxy.tar.gz --strip 1 -C /go/src/github.com/DNSCrypt \
 	#&& go get -u all \
 	&& go mod download golang.org/x/sync \

--- a/dnsx/Dockerfile
+++ b/dnsx/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk update \
 	&& apk upgrade -a \
 	&& apk add --no-cache curl gcc musl-dev \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/dnsx.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/dnsx.tar.gz \
 	&& tar xzf /tmp/dnsx.tar.gz --strip 1 -C /go/src/github.com/projectdiscovery/dnsx \
 	&& go get -u github.com/quic-go/quic-go \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/dry/Dockerfile
+++ b/dry/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk update \
 	&& apk upgrade -a \
 	&& apk add --no-cache curl gcc musl-dev \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/dry.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/dry.tar.gz \
 	&& tar xzf /tmp/dry.tar.gz --strip 1 -C /go/src/github.com/moncho/dry \
 	#&& go get -u github.com/containerd/containerd@v1.6.21 \
 	#&& go get -u github.com/docker/docker@v25.0.6 github.com/docker/cli@v25.0.6 \

--- a/fq/Dockerfile
+++ b/fq/Dockerfile
@@ -15,7 +15,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl git gcc build-base \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/fq.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/fq.tar.gz \
 	&& tar xzf /tmp/fq.tar.gz --strip 1 -C /go/src/github.com/wader/fq \ 
 	&& go get -u golang.org/x/crypto golang.org/x/net \
 	&& go build -o fq -v -trimpath -ldflags="-s -w -X main.version=${BUILD_VERSION}" .

--- a/gobgp/Dockerfile
+++ b/gobgp/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/gobgp.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/gobgp.tar.gz \
 	&& tar xzf /tmp/gobgp.tar.gz --strip 1 -C /go/src/github.com/osrg/gobgp \
 	&& go get -u golang.org/x/net \
 	&& go mod tidy \

--- a/gocannon/Dockerfile
+++ b/gocannon/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/gocannon.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/gocannon.tar.gz \
 	&& tar xzf /tmp/gocannon.tar.gz --strip 1 -C /go/src/github.com/kffl/gocannon \
 	&& go build -v -trimpath -ldflags="-s -w" . 
 

--- a/headscale/Dockerfile
+++ b/headscale/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/headscale.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/headscale.tar.gz \
 	&& tar xzf /tmp/headscale.tar.gz --strip 1 -C /go/src/github.com/juanfont/headscale \
 	&& go get -u github.com/jackc/pgx/v5 github.com/go-jose/go-jose/v3 google.golang.org/grpc google.golang.org/genproto google.golang.org/protobuf \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/httpx/Dockerfile
+++ b/httpx/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk update \
 	&& apk upgrade -a \
 	&& apk add --no-cache curl gcc musl-dev \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/httpx.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/httpx.tar.gz \
 	&& tar xzf /tmp/httpx.tar.gz --strip 1 -C /go/src/github.com/projectdiscovery/httpx \
 	&& go get -u github.com/quic-go/quic-go \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/lego/Dockerfile
+++ b/lego/Dockerfile
@@ -14,7 +14,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl make git gcc build-base \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/lego.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/lego.tar.gz \
 	&& tar xzf /tmp/lego.tar.gz --strip 1 -C /go/src/github.com/go-acme/lego \
 	&& go get -u google.golang.org/grpc google.golang.org/protobuf \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/logmepwn/Dockerfile
+++ b/logmepwn/Dockerfile
@@ -15,7 +15,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl git gcc build-base \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/logmepwn.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/logmepwn.tar.gz \
 	&& tar xzf /tmp/logmepwn.tar.gz --strip 1 -C /go/src/github.com/0xInfection/logmepwn \ 
 	&& go get -u golang.org/x/crypto golang.org/x/net github.com/valyala/fasthttp \ 
 	&& go build -o lmp -v -trimpath -ldflags="-s -w" .

--- a/nebula/Dockerfile
+++ b/nebula/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/nebula.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/nebula.tar.gz \
 	&& tar xzf /tmp/nebula.tar.gz --strip 1 -C /go/src/github.com/slackhq/nebula \
 	&& go get -u google.golang.org/protobuf golang.org/x/crypto golang.org/x/net \
 	&& go mod tidy \

--- a/netmaker/Dockerfile
+++ b/netmaker/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/netmaker.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/netmaker.tar.gz \
 	&& tar xzf /tmp/netmaker.tar.gz --strip 1 -C /go/src/github.com/gravitl/netmaker \
 	&& go get -u github.com/go-jose/go-jose/v3 github.com/jackc/pgx/v5 \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/ntfy/Dockerfile
+++ b/ntfy/Dockerfile
@@ -15,7 +15,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl git gcc build-base \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/ntfy.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/ntfy.tar.gz \
 	&& tar xzf /tmp/ntfy.tar.gz --strip 1 -C /go/src/github.com/binwiederhier/ntfy \ 
 	&& mkdir server/docs \ 
 	&& touch server/docs/dummy \ 

--- a/octosql/Dockerfile
+++ b/octosql/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/octosql.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/octosql.tar.gz \
 	&& tar xzf /tmp/octosql.tar.gz --strip 1 -C /go/src/github.com/cube2222/octosql \
 	&& go get -u golang.org/x/net golang.org/x/crypto gopkg.in/yaml.v3 github.com/jackc/pgx google.golang.org/grpc google.golang.org/genproto github.com/mholt/archiver \
 	&& go get -u github.com/jackc/pgx/v4 \

--- a/onetun/Dockerfile
+++ b/onetun/Dockerfile
@@ -11,7 +11,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk update \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl lld g++ musl-dev \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/onetun.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/onetun.tar.gz \
 	&& tar xzf /tmp/onetun.tar.gz --strip 1 -C /usr/src/github.com/aramperes/onetun \
 	&& RUSTFLAGS="-C link-arg=-fuse-ld=lld" cargo build --release \
 	&& strip target/release/onetun

--- a/rclone/Dockerfile
+++ b/rclone/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk update \
 	&& apk upgrade -a \
 	&& apk add --no-cache curl gcc musl-dev \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/rclone.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/rclone.tar.gz \
 	&& tar xzf /tmp/rclone.tar.gz --strip 1 -C /go/src/github.com/rclone/rclone \
 	&& go get -u golang.org/x/net \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/snowball/Dockerfile
+++ b/snowball/Dockerfile
@@ -18,18 +18,22 @@ RUN test -n "${BUILD_VERSION}" && test -n "${NETTY_VERSION}" && test -n "${BC_VE
 	&& apt-get update \
 	&& apt-get dist-upgrade -y \
 	&& DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl \
-	&& curl -L "${TARBALL_URL}" -o /tmp/snowball.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${TARBALL_URL}" -o /tmp/snowball.tar.gz \
 	&& tar xzf /tmp/snowball.tar.gz --strip 1 -C /usr/local \
 	&& rm -rf /tmp/snowball.tar.gz \
 	&& cd /usr/local/jarfarm \
 	&& for f in netty-*-4.1.jar netty-*-4.1-*.jar; do \
 		[ -e "$f" ] || continue; \
 		rest=${f%.jar}; artifact=${rest%%-4.1*}; suffix=${rest#*-4.1}; classifier=${suffix#-}; \
-		curl -fsSL "https://repo1.maven.org/maven2/io/netty/${artifact}/${NETTY_VERSION}/${artifact}-${NETTY_VERSION}${classifier:+-$classifier}.jar" -o "$f"; \
+		jar="${artifact}-${NETTY_VERSION}${classifier:+-$classifier}.jar"; \
+		curl -fsSL --proto "=https" --proto-redir "=https" \
+			"https://repo1.maven.org/maven2/io/netty/${artifact}/${NETTY_VERSION}/${jar}" -o "$f"; \
 	done \
 	&& for a in bcprov bcpg bcpkix bcutil bcmail bctls; do \
 		rm -f "${a}-jdk18on-"*.jar; \
-		curl -fsSL "https://repo1.maven.org/maven2/org/bouncycastle/${a}-jdk18on/${BC_VERSION}/${a}-jdk18on-${BC_VERSION}.jar" -o "${a}-jdk18on-${BC_VERSION}.jar"; \
+		curl -fsSL --proto "=https" --proto-redir "=https" \
+			"https://repo1.maven.org/maven2/org/bouncycastle/${a}-jdk18on/${BC_VERSION}/${a}-jdk18on-${BC_VERSION}.jar" \
+			-o "${a}-jdk18on-${BC_VERSION}.jar"; \
 	done \
 	&& cd / \
 	&& apt-get purge -y curl \

--- a/spicedb/Dockerfile
+++ b/spicedb/Dockerfile
@@ -16,7 +16,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/spicedb.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/spicedb.tar.gz \
 	&& tar xzf /tmp/spicedb.tar.gz --strip 1 -C /go/src/github.com/authzed/spicedb \
 	&& go get -u golang.org/x/net \
 	&& go build -o ./spicedb -v -trimpath -ldflags="-s -w" ./cmd/spicedb 

--- a/ssh-audit/Dockerfile
+++ b/ssh-audit/Dockerfile
@@ -12,7 +12,8 @@ RUN test -n "${BUILD_VERSION}" \
     && runtime_pkgs="ca-certificates python3" \
     && apk add --no-cache --virtual build-dependencies ${build_pkgs} \
     && apk add --no-cache ${runtime_pkgs}  \
-    && curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/ssh-audit.tar.gz \
+    && curl -L --proto "=https" --proto-redir "=https" \
+            "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/ssh-audit.tar.gz \
     && tar xvzf /tmp/ssh-audit.tar.gz --strip 1 -C /home/ssh-audit \
     && addgroup ssh-audit \
     && adduser -G ssh-audit -g "ssh-audit user" -s /bin/bash -D ssh-audit \ 

--- a/subfinder/Dockerfile
+++ b/subfinder/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk update \
 	&& apk upgrade -a \
 	&& apk add --no-cache curl gcc musl-dev \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/subfinder.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/subfinder.tar.gz \
 	&& tar xzf /tmp/subfinder.tar.gz --strip 1 -C /go/src/github.com/projectdiscovery/subfinder \
 	&& go get -u github.com/quic-go/quic-go \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -15,7 +15,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl git gcc build-base \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/tailscale.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/tailscale.tar.gz \
 	&& tar xzf /tmp/tailscale.tar.gz --strip 1 -C /go/src/github.com/tailscale/tailscale \
 	&& go get -u golang.org/x/net \
 	&& go get -u golang.org/x/crypto golang.org/x/net \

--- a/templates/Dockerfile.go-tar
+++ b/templates/Dockerfile.go-tar
@@ -13,7 +13,8 @@ ENV CGO_ENABLED 0
 RUN test -n "${BUILD_VERSION}" \
 	&& apk update \
 	&& apk add --no-cache ca-certificates curl \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/dnscrypt-proxy.tar.gz \
+	&& curl -L --proto "=https" --proto-redir "=https" \
+		"${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/dnscrypt-proxy.tar.gz \
 	&& tar xzf /tmp/dnscrypt-proxy.tar.gz --strip 1 -C /go/src/github.com/DNSCrypt \
 	&& go build -v -ldflags="-s -w"
 

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -15,7 +15,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl git gcc build-base \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/terraform.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/terraform.tar.gz \
 	&& tar xzf /tmp/terraform.tar.gz --strip 1 -C /go/src/github.com/hashicorp/terraform \
 	#&& go get -u github.com/hashicorp/go-getter github.com/cloudflare/circl google.golang.org/protobuf golang.org/x/net \
 	#&& go get -u go.opentelemetry.io/otel/sdk/trace \

--- a/testssl.sh/Dockerfile
+++ b/testssl.sh/Dockerfile
@@ -9,7 +9,7 @@ RUN test -n "${BUILD_VERSION}" \
     && apk update \
     && apk upgrade -a \
     && apk add --no-cache bash procps drill coreutils libidn curl socat openssl xxd \
-    && curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/testssl.tar.gz \
+    && curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/testssl.tar.gz \
     && tar xzf /tmp/testssl.tar.gz --strip 1 -C /home/testssl \
     && addgroup testssl \
     && adduser -G testssl -g "testssl user" -s /bin/bash -D testssl \

--- a/testssl.sh/Dockerfile.ubuntu
+++ b/testssl.sh/Dockerfile.ubuntu
@@ -11,7 +11,7 @@ RUN test -n "${BUILD_VERSION}" \
     && apt-get dist-upgrade -y \
     && DEBIAN_FRONTEND=${DEBIAN_FRONTEND} apt-get install -y --no-install-recommends bash procps dnsutils coreutils libidn12 curl ca-certificates socat openssl xxd bsdextrautils \
     && rm -rf /usr/bin/pebble \
-    && curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/testssl.tar.gz \
+    && curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/testssl.tar.gz \
     && tar xzf /tmp/testssl.tar.gz --strip 1 -C /home/testssl \
     && groupadd --system testssl \
     && useradd --system --gid testssl --shell /bin/bash --home-dir /home/testssl testssl \

--- a/toxiproxy/Dockerfile
+++ b/toxiproxy/Dockerfile
@@ -15,7 +15,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl git gcc build-base \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/toxiproxy.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/toxiproxy.tar.gz \
 	&& tar xzf /tmp/toxiproxy.tar.gz --strip 1 -C /go/src/github.com/shopify/toxiproxy \ 
 	&& go get -u ./... \
 	&& go get -u all \

--- a/trufflehog/Dockerfile
+++ b/trufflehog/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/trufflehog.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/trufflehog.tar.gz \
 	&& tar xzf /tmp/trufflehog.tar.gz --strip 1 -C /go/src/github.com/trufflesecurity/trufflehog \
 	&& go build -o ./trufflehog -v -trimpath -ldflags="-s -w -X main.Version=${BUILD_VERSION}" .
 

--- a/xormon-ng/Dockerfile
+++ b/xormon-ng/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update \
 
 # Node.js 24 (glibc prebuilt) into /usr/local; drop C++ headers/docs (only
 # needed to compile native addons, which we never do at runtime) - saves ~63MB
-RUN curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" -o /tmp/node.tar.xz \
+RUN curl -fsSL --proto "=https" --proto-redir "=https" \
+        "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" -o /tmp/node.tar.xz \
     && tar xf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
     && rm /tmp/node.tar.xz \
     && rm -rf /usr/local/include /usr/local/CHANGELOG.md /usr/local/README.md \

--- a/yggdrasil-go/Dockerfile
+++ b/yggdrasil-go/Dockerfile
@@ -13,7 +13,8 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl gcc musl-dev \
 	&& update-ca-certificates \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/yggdrasil-go.tar.gz \
+	&& curl -L --proto "=https" --proto-redir "=https" \
+		"${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/yggdrasil-go.tar.gz \
 	&& tar xzf /tmp/yggdrasil-go.tar.gz --strip 1 -C /go/src/github.com/yggdrasil-network/yggdrasil-go \
 	&& go get -u golang.org/x/tools \
 	#&& go get -u github.com/quic-go/quic-go \

--- a/youtube-dl/Dockerfile
+++ b/youtube-dl/Dockerfile
@@ -18,7 +18,8 @@ RUN set -x \
         python3 \
     # Install youtube-dl
     # https://github.com/rg3/youtube-dl
- && curl -Lo /usr/local/bin/youtube-dl https://github.com/ytdl-org/youtube-dl/releases/download/2021.12.17/youtube-dl \
+ && curl -Lo /usr/local/bin/youtube-dl --proto "=https" --proto-redir "=https" \
+        https://github.com/ytdl-org/youtube-dl/releases/download/2021.12.17/youtube-dl \
  #&& curl -Lo /usr/local/bin/youtube-dl https://yt-dl.org/downloads/latest/youtube-dl \
  #&& curl -Lo youtube-dl.sig https://yt-dl.org/downloads/latest/youtube-dl.sig \
  #&& gpg --keyserver keyserver.ubuntu.com --recv-keys '7D33D762FD6C35130481347FDB4B54CBA4826A18' \

--- a/zola/Dockerfile
+++ b/zola/Dockerfile
@@ -12,7 +12,7 @@ RUN test -n "${BUILD_VERSION}" \
 	&& apk update \
 	&& apk upgrade -a \
 	&& apk add --no-cache ca-certificates curl openssl-dev g++ build-base musl-dev make mold \
-	&& curl -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/zola.tar.gz \
+	&& curl --proto "=https" --proto-redir "=https" -L "${ARCHIVE_URL}${BUILD_VERSION}.tar.gz" -o /tmp/zola.tar.gz \
 	&& tar xzf /tmp/zola.tar.gz --strip 1 -C /usr/src/github.com/getzola/zola \
 	&& RUSTFLAGS="-C link-arg=-fuse-ld=mold -C target-feature=-crt-static" cargo build --release \
 	&& strip target/release/zola


### PR DESCRIPTION
Follow-up to #7840, which fixed this pattern in `yt-dlp` only. SonarCloud flagged `docker:S6506` there because it scores *new* code; the same shape existed repo-wide and went unrated.

## Change

Added `--proto "=https" --proto-redir "=https"` to all **43 curl invocations across 41 Dockerfiles**.

Every one fetched a release artifact with `-L` and no protocol restriction, so a redirect could downgrade the transfer to plaintext. The two flags cover different hops:

- `--proto "=https"` rejects a plaintext *starting* URL — relevant because `ARCHIVE_URL`, `TARBALL_URL` and `BUILD_VERSION` are overridable build ARGs
- `--proto-redir "=https"` is what actually stops a redirect from downgrading mid-chain

Most changes are a one-line insertion. Ten lines would have crossed the 120-char limit for a RUN line (`docker:S7020`), so those are split across continuations following each file's own indentation.

One case needed more: in `snowball`, the netty URL is too long even after splitting, so the jar filename moves into a `jar` variable first. The constructed URL is byte-identical — see verification below.

Not touched: 4 commented-out curl lines, and `yt-dlp`, which already has this from #7840.

## Verification

No image was assumed to be fine.

**Every URL, live.** Reconstructed all 37 real download URLs from each Dockerfile's `ARG` defaults plus its workflow's `BUILD_VERSION`, and fetched each with the new flags: **37/37 returned 200, 0 failures.** The `github.com → codeload.github.com` redirect hop is exercised and stays HTTPS. Also confirmed one live fetch per distinct host: `github.com`, `raw.githubusercontent.com`, `repo1.maven.org`, `nodejs.org` — all 200.

**Shell syntax, repo-wide.** The real risk in a mechanical sweep is a botched line split, so I parsed every `RUN` in the repo (joining continuations, honouring comment lines inside a continued instruction) and ran `sh -n` on each: **216 RUN instructions checked, 0 failures.**

**Real builds.** Eight images built `--no-cache` from scratch, covering 6 of the 10 hand-split files plus samples of the scripted change — all pass:

`ali` · `dry` · `ssh-audit` · `youtube-dl` · `catprinter` · `dnscrypt-proxy` · `yggdrasil-go` · `adguardhome`

**snowball**, the riskiest change, separately: a differential test of old vs new URL construction over 6 jar-name shapes including the `${classifier:+-$classifier}` case produced **0 mismatches**, and both curl loops (netty + bouncycastle) ran live — **8/8 downloads OK**. Its full build fails on this machine at `tar: Cannot mkdir: Function not implemented`, but the unmodified `origin/main` version fails identically, so that's QEMU emulation of amd64, not this change.

**xormon-ng** can't build natively on arm64 (it downloads a `linux-x64` Node tarball), so its exact URL was verified live instead: 200.

**No `http://` URLs exist** anywhere in the repo's curl calls, so `--proto "=https"` cannot reject a legitimate download.

## Note for review

This is deliberately a separate PR from #7840 rather than an extension of it — it's a mechanical 41-file sweep and mixing it into a focused bugfix would have made both harder to review. The diff is uniform enough to skim: 43 changed lines, 33 of them a single inserted flag pair.
