### PR TITLE
ntfy: document base-url requirement for iOS push

### DIFF
--- a/ntfy/README.md
+++ b/ntfy/README.md
@@ -8,13 +8,36 @@ Up to date multi-platform images are built an hour after upstream release and re
 
 ## iOS Push Notifications
 
-iOS push notifications require relaying through ntfy.sh's APNs gateway. Without this, messages will not be delivered to iOS devices when the app is backgrounded.
+A self-hosted server cannot talk to APNs directly, so it must forward `poll_request` messages
+through an APNs-connected upstream server (normally ntfy.sh). Only the message ID is forwarded;
+the message body stays on your server.
 
-Add the following to your `server.yml`:
+Both settings below are required. ntfy refuses to start if `upstream-base-url` is set without
+`base-url`, and `base-url` must match the URL your clients subscribe to, because the upstream
+topic is derived from the topic URL.
 
 ```yaml
-upstream-base-url: "https://ntfy.sh"
+# /etc/ntfy/server.yml
+base-url: "https://ntfy.example.com"    # your public URL, no trailing slash, no path
+upstream-base-url: "https://ntfy.sh"    # must differ from base-url
+#upstream-access-token: "tk_..."        # only if you exceed ntfy.sh rate limits
 ```
 
-See the [ntfy documentation](https://docs.ntfy.sh/config/#ios-instant-notifications) for details.
+The config file is read from `/etc/ntfy/server.yml` by default:
+
+```
+docker run -p 80:80 -v /path/to/server.yml:/etc/ntfy/server.yml:ro jauderho/ntfy serve
+```
+
+The same settings can be passed as environment variables instead:
+
+```
+docker run -p 80:80 \
+	-e NTFY_BASE_URL=https://ntfy.example.com \
+	-e NTFY_UPSTREAM_BASE_URL=https://ntfy.sh \
+	jauderho/ntfy serve
+```
+
+Without `upstream-base-url`, iOS messages still arrive, but delivery is delayed. See the
+[ntfy documentation](https://docs.ntfy.sh/config/#ios-instant-notifications) for details.
 


### PR DESCRIPTION
Fixes #5050. Supersedes #5334.

## Problem

`ntfy/README.md` told users to put this in `server.yml`:

```yaml
upstream-base-url: "https://ntfy.sh"
```

ntfy refuses to start with that config:

```
if upstream-base-url is set, base-url must also be set
```

The check is at [`cmd/serve.go`](https://github.com/binwiederhier/ntfy/blob/main/cmd/serve.go) (`upstreamBaseURL != "" && baseURL == ""`). So following the README produced a server that would not boot.

`base-url` matters for a second reason: the upstream Firebase topic is the SHA256 of the topic URL, so an absent or wrong `base-url` sends the `poll_request` to a topic no device is subscribed to.

## Changes

`ntfy/README.md` only. No Dockerfile changes.

- Add the required `base-url` alongside `upstream-base-url`, with the constraints (no trailing slash, no path, must differ from `upstream-base-url`).
- Add the `NTFY_BASE_URL` / `NTFY_UPSTREAM_BASE_URL` environment variable form.
- State the default config path, `/etc/ntfy/server.yml`.
- Mention `upstream-access-token` for the rate-limit case.
- Correct the claim that iOS messages "will not be delivered" without an upstream server. Per upstream docs, delivery is delayed, not dropped.

## Verification

Built locally from `ntfy/Dockerfile` at `BUILD_VERSION=v2.27.0`:

| Check | Result |
| --- | --- |
| Old README config (`upstream-base-url` alone) | fails: `if upstream-base-url is set, base-url must also be set` |
| New README yaml block, verbatim | starts: `Listening on :80[http], ntfy v2.27.0` |
| `NTFY_BASE_URL` + `NTFY_UPSTREAM_BASE_URL` | starts |
| Publish then poll round trip | message returned intact |

## Note on #5334

#5334 documents APNS credentials (`.p8` auth key, Key ID, Team ID) in `server.yml`, and adds commented `NTFY_IOS_KEY_ID` / `NTFY_IOS_TEAM_ID` / `NTFY_IOS_PRIVATE_KEY_FILE` hints to the Dockerfile. Those options do not exist in ntfy; self-hosted servers never handle APNs credentials directly. It also links to a `#ios-notifications-apns` anchor that is not on the page, and adds `VOLUME /etc/ntfy` to a config directory, which creates an anonymous volume on every `docker run` that omits a mount. Upstream's Dockerfile declares no `VOLUME`, and the bind mount works without it. Recommend closing #5334.
